### PR TITLE
Remove unused solid_cable config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,8 +3,6 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.solid_cable.enabled = false
-
   # Code is not reloaded between requests.
   config.enable_reloading = false
 


### PR DESCRIPTION
・config/environments/production.rbにconfig.solid_cable.enabled = falseを追加
・gem solid_cable削除
・config/environments/production.rbにconfig.solid_cable.enabled = falseを削除